### PR TITLE
colors, mg/dl, new calc of delta

### DIFF
--- a/TrendArrow.lua
+++ b/TrendArrow.lua
@@ -1,15 +1,56 @@
 function Update()
-    arrows = {
-        ['Flat'] = "[\\11106]",
-        ['SingleUp'] = "[\\11141]",
-        ['SingleDown'] = "[\\11143]",
-        ['FortyFiveUp'] = "[\\11111]",
-        ['FortyFiveDown'] = "[\\11112]",
+    local arrows = {
+        [-1.0] = "[\\11143]",
+        [-0.9] = "[\\11143]",
+        [-0.8] = "[\\11143]",
+        [-0.7] = "[\\11112]",
+        [-0.6] = "[\\11112]",
+        [-0.5] = "[\\11112]",
+        [-0.4] = "[\\11112]",
+        [-0.3] = "[\\11106]",
+        [-0.2] = "[\\11106]",
+        [-0.1] = "[\\11106]",
+        [ 0.0] = "[\\11106]",
+        [ 0.1] = "[\\11106]",
+        [ 0.2] = "[\\11106]",
+        [ 0.3] = "[\\11106]",
+        [ 0.4] = "[\\11111]",
+        [ 0.5] = "[\\11111]",
+        [ 0.6] = "[\\11111]",
+        [ 0.7] = "[\\11111]",
+        [ 0.8] = "[\\11141]",
+        [ 0.9] = "[\\11141]",
+        [ 1.0] = "[\\11141]",
     }
-    MeasureObject = SKIN:GetMeasure('SGVParserBGArrow')
-    print(MeasureObject:GetStringValue())
-    -- print(MeasureObject:GetValue())
 
-    SKIN:Bang('!SetOption', 'MeterArrow', 'Text', arrows[MeasureObject:GetStringValue()])
+    local measureObject = SKIN:GetMeasure('MeasureBGDelta')
+    local displayDelta = round(measureObject:GetValue(), 1)
 
+    local unitFactor = tonumber(SKIN:GetVariable('unitFactor')) or 0.0555
+
+    -- Для стрелок всегда приводим к mmol/L
+    local arrowDelta = round(displayDelta * (0.0555 / unitFactor), 1)
+
+    if arrowDelta > 1 then
+        SKIN:Bang('!SetOption', 'MeterArrow', 'Text', '[\\11141]')
+    elseif arrowDelta < -1 then
+        SKIN:Bang('!SetOption', 'MeterArrow', 'Text', '[\\11143]')
+    else
+        SKIN:Bang('!SetOption', 'MeterArrow', 'Text', arrows[arrowDelta] or "[\\11106]")
+    end
+
+    if displayDelta > 0 then
+        SKIN:Bang('!SetOption', 'MeterBGDelta', 'Text', '+' .. displayDelta)
+    else
+        SKIN:Bang('!SetOption', 'MeterBGDelta', 'Text', displayDelta)
+    end
+end
+
+function round(num, numDecimalPlaces)
+    local mult = 10 ^ (numDecimalPlaces or 0)
+    if num >= 0 then
+        return math.floor(num * mult + 0.5) / mult
+    else
+        return math.ceil(num * mult - 0.5) / mult
+    end
 end

--- a/nighstcout.ini
+++ b/nighstcout.ini
@@ -32,14 +32,19 @@ ClipString=1
 [styleSeperator]
 SolidColor=255,255,255,15
 
+[MeasureTime]
+Measure=Time
+Format=%H%M%S
+
 [Data]
 Measure=Plugin
 Plugin=WebParser.dll
-URL=https://#DOMAIN#/api/v1/entries/?count=1&token=#TOKEN#
+URL=https://#DOMAIN#/api/v1/entries/?count=2&token=#TOKEN#&_ts=[&MeasureTime]  ; if you dont have ssl on server use http
 Header=Accept: application/json
 RegExp=(?siU)^(.*)$
 UpdateRate=1
 DynamicVariables=1
+FinishAction=[!EnableMeasure "SGVParserBG"][!EnableMeasure "SGVParserPrevBG"][!EnableMeasure "SGVParserBGDate"][!EnableMeasure "SGVParserBGArrow"][!UpdateMeasure "SGVParserBG"][!UpdateMeasure "SGVParserPrevBG"][!UpdateMeasure "SGVParserBGDate"][!UpdateMeasure "SGVParserBGArrow"][!EnableMeasure "TrendArrowScript"][!EnableMeasure "EpochConvertScript"][!UpdateMeasure "TrendArrowScript"][!UpdateMeasure "EpochConvertScript"][!UpdateMeasure "MeasureBG"][!UpdateMeasure "MeasureBGDelta"][!UpdateMeasure "MeasureBGState"][!UpdateMeasure "MeasureBGColorLogic"][!UpdateMeter *][!Redraw]
 
 [Rainmeter]
 ; This section contains general settings that can be used to change how Rainmeter behaves.
@@ -50,12 +55,30 @@ AccurateText=1
 
 [Variables]
 ; Variables declared here can be used later on between two # characters (e.g. #MyVariable#).
-TOKEN = <replace-with-your-nightscout-token>
-DOMAIN = <replace-with-your-nightscout-domain>
+TOKEN = <replace-with-your-nightscout-token>    ;<<-------------------------
+DOMAIN = <replace-with-your-nightscout-domain>   ;<<-------------------------
 fontName=Comfortaa
 textSize=20
 colorBar=235,170,0,255
 colorText=255,255,255,205
+
+colorNormal=0,255,0,205      ; Color for normal sugar level 
+colorHigh=255,255,0,205      ; Color for High sugar level 
+colorLow=255,0,0,205         ; Color for ow sugar level 
+
+; thr for mg/dL
+;lowThr=70
+;highThr=180  
+
+; thr for mmol/l
+lowThr=3.9
+highThr=10
+
+; Units:
+; mmol/L -> unitFactor=0.0555, unitLabel=mmol/l
+; mg/dL  -> unitFactor=1,      unitLabel=mg/dL
+unitFactor=0.0555
+unitLabel=mmol/l
 
 [SGVParserBG]
 Measure=Plugin
@@ -64,6 +87,17 @@ Source=[Data]
 Logging=NoMatch:1,EmptySource:1
 Query="[0].sgv"
 DynamicVariables=1
+Disabled=1
+
+[SGVParserPrevBG]
+DynamicVariables=1
+Measure=Plugin
+Plugin=JsonParser.dll
+Source=[Data]
+Logging=NoMatch:1,EmptySource:1
+Query="[1].sgv"
+DynamicVariables=1
+Disabled=1
 
 [SGVParserBGDate]
 Measure=Plugin
@@ -72,6 +106,7 @@ Source=[Data]
 Logging=NoMatch:1,EmptySource:1
 Query="[0].date"
 DynamicVariables=1
+Disabled=1
 
 [SGVParserBGArrow]
 Measure=Plugin
@@ -79,38 +114,67 @@ Plugin=JsonParser.dll
 Source=[Data]
 Logging=NoMatch:1,EmptySource:1
 Query="[0].direction"
-UpdateRate=1
+UpdateRate=50100
 DynamicVariables=1
+Disabled=1
 
 [MeasureBG]
 Measure=Calc
-Formula=SGVParserBG*0.0555
+Formula=SGVParserBG*#unitFactor#
+DynamicVariables=1
+
+[MeasureBGDelta]
+Measure=Calc
+Formula=(SGVParserBG - SGVParserPrevBG)*#unitFactor#
 DynamicVariables=1
 
 [TrendArrowScript]
 Measure=Script
 ScriptFile=TrendArrow.lua
 DynamicVariables=1
+Disabled=1
 
 [EpochConvertScript]
 Measure=Script
 ScriptFile=EpochConvert.lua
 UpdateRate=1
 DynamicVariables=1
+Disabled=1
+
+[MeasureBGState]
+Measure=Calc
+Formula=(MeasureBG < #lowThr# ? 0 : (MeasureBG > #highThr# ? 2 : 1))
+DynamicVariables=1
+;OnUpdateAction=[!Log "BG State: [MeasureBGState] BG=[MeasureBG]" "Notice"]
+
+[MeasureBGColorLogic]
+Measure=Calc
+Formula=MeasureBGState
+DynamicVariables=1
+
+IfCondition=(MeasureBGState = 0)
+IfTrueAction=[!SetOption SVGMeter FontColor "#colorLow#"][!UpdateMeter SVGMeter][!Redraw]
+
+IfCondition2=(MeasureBGState = 1)
+IfTrueAction2=[!SetOption SVGMeter FontColor "#colorNormal#"][!UpdateMeter SVGMeter][!Redraw]
+
+IfCondition3=(MeasureBGState = 2)
+IfTrueAction3=[!SetOption SVGMeter FontColor "#colorHigh#"][!UpdateMeter SVGMeter][!Redraw]
 
 [SVGMeter]
 Meter=String
 MeterStyle=styleCenterText
 MeasureName=MeasureBG
-FontSize=40
+FontSize=36
 H=70
 W=500
 Y=50
 X=175
-Text=%1 mmol/l
+Text=%1 #unitLabel#
 AntiAlias=1
 NumOfDecimals=1
 DynamicVariables=1
+FontColor=#colorText#
 
 [MeterArrow]
 Meter=String
@@ -132,3 +196,15 @@ X=40
 Y=115
 AntiAlias=1
 DynamicVariables=1
+
+[MeterBGDelta]
+Meter=String
+MeasureName=MeasureBGDelta
+MeterStyle=styleCenterText
+StringAlign=Left
+X=230
+Y=115
+AntiAlias=1
+DynamicVariables=1
+
+


### PR DESCRIPTION
**Changes**

Removed dependency on the optional delta field from Nightscout API
→ Delta is now calculated using the last two entries (sgv values)

Implemented delta calculation based on recent entries
→ Uses count=2 and computes current - previous

Added unit support
→ Introduced unitFactor and unitLabel variables
→ Supports both mmol/L and mg/dL

Normalized arrow logic
→ Arrow calculation is now unit-independent
→ Internally converts delta to mmol/L for consistent behavior

Added glucose range colorization
→ Low / Normal / High thresholds (lowThr, highThr)
→ Dynamic color updates for glucose value display

Improved robustness of JSON parsing
→ Prevented startup errors (Error reading JToken...)
→ JsonParser measures are now initialized only after data is loaded

Fixed caching issue
→ Added timestamp parameter to API requests to force fresh data

Cleaned up configuration
→ Removed redundant / conflicting measure definitions
→ Standardized variable usage and formulas

**Result:**
<img width="397" height="180" alt="изображение" src="https://github.com/user-attachments/assets/456c66d6-ee7f-4056-bc4d-31975fa7b24d" />
